### PR TITLE
Added Docker support :) 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+.git
+.idea
+/tmp

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DOMAIN_NAME="localhost"
+DOMAIN_NAME="0.0.0.0"
 PORT=":3000"
 PROTOCOL="http://"
 PGUSER=postgres

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DOMAIN_NAME="localhost"
 PORT=":3000"
 PROTOCOL="http://"
+PGUSER=postgres

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ public/system/dragonfly
 /log/*
 !/log/.keep
 /tmp
+.idea
 
 .env
 .byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ public/system/dragonfly
 !/log/.keep
 /tmp
 .idea
-
 .env
 .byebug_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,3 @@ ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 RUN bundle install
 ADD . /app
-
-CMD ["rails","s","-b","0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.3
+RUN mkdir /app
+WORKDIR /app
+ADD Gemfile Gemfile
+ADD Gemfile.lock Gemfile.lock
+RUN bundle install
+ADD . /app
+
+CMD ["rails","s","-b","0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development do
   gem 'poltergeist'
   gem 'dotenv-rails'
   gem 'rmagick'
-  gem 'spectre_client', git: 'git@github.com:wearefriday/spectre_client.git'
+  gem 'spectre_client', github: 'wearefriday/spectre_client'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:wearefriday/spectre_client.git
+  remote: git://github.com/wearefriday/spectre_client.git
   revision: c111d78bd3811c63ed6d11503e950feb8bfcce5d
   specs:
     spectre_client (0.1.87)

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ development:
   encoding: utf8
   database: spectre_development
   pool: 5
+  host: db
   username:
   password:
 
@@ -11,6 +12,7 @@ production:
   encoding: utf8
   database: wafi-spectre
   pool: 5
+  host: db
   username: deploy
   port: 5432
 
@@ -19,6 +21,7 @@ test: &test
   encoding: utf8
   database: spectre_test
   pool: 5
+  host: db
   username:
   password:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  web:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    env_file:
+      - '.env.example'
+    depends_on:
+      - db
+
+  db:
+    image: postgres
+    ports:
+      - "5432"
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 services:
   web:
     build: .
@@ -8,12 +8,10 @@ services:
       - "3000:3000"
     env_file:
       - '.env.example'
+    command: bundle exec rails s -b '0.0.0.0'
     depends_on:
       - db
-
   db:
     image: postgres
     ports:
       - "5432"
-
-


### PR DESCRIPTION
```docker-compose build```
```docker-compose up -d``` (start in background so we can init the DB)
```docker-compose run web /bin/bash -c 'bundle exec rake db:create && bundle exec rake db:schema:load'```

You now have an initialized and ready to use version of spectre!  

concerns:

1. I added 'host' to the database.yml , might be best to add a new entry for using docker so that it does not affect non-docker runs. 

2. you will lose your DB if you delete the postgres container or do docker-compose down. We could link it to an external DB to make things more 'permanent'.

We are still fairly new to Docker & Rails so there may be a much better way to do this, figured I would throw it up just for fun. We had lots of errors on OSX when installing locally (V8 related), so it was great to have Docker save the day.