### PR TITLE
Add "Deploy to Heroku" button for easy set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Spectre is a web application to diff screenshots. It's heavily influence by [Vis
 * `bundle exec rails s`
 * Copy `.env.example` and rename to `.env`. Change the url details if you need to.
 
+Alternatively:
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Submitting tests
 
 A "test" is a screenshot and associated metadata. A test is categorised under a Project, which in turn has (test) Suites. A test is submitted and associated with a "run" of a suite.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,27 @@
+{
+  "name": "Spectre",
+  "description": "A web application to diff screenshots",
+  "keywords": [
+    "testing",
+    "ui"
+  ],
+  "repository": "https://github.com/wearefriday/spectre",
+  "success_url": "/",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:create && bundle exec rake db:schema:load"
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "image": "heroku/ruby",
+  "addons": [
+    {
+      "plan": "heroku-postgresql",
+      "options": {
+        "version": "9.5"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This makes it super easy to get a Spectre server running on the Heroku platform. 

![image](https://cloud.githubusercontent.com/assets/706039/17718389/4a39eb52-63d9-11e6-8dc5-dc9e98c348ff.png)

[Example of it running after deploy](https://calm-savannah-89836.herokuapp.com/projects/my-project-name/suites/my-suite)