### PR TITLE
Av/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 1.9
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+bundler_args: --without demo_test_run

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,11 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.3
 bundler_args: --without demo_test_run
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database spectre_test;' -U postgres
+addons:
+  postgresql: "9.4"

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,6 @@ gem 'unicorn'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
-  gem 'cucumber-rails', require: false
-  gem 'database_cleaner'
   gem 'rest-client'
   gem 'rspec-rails'
   gem "factory_girl_rails", "~> 4.0"
@@ -43,6 +41,12 @@ group :development do
   gem 'web-console', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+group :test do
+  gem 'cucumber-rails', require: false
+  gem 'database_cleaner'
+  gem 'poltergeist'
 end
 
 group :demo_test_run do

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spectre
 
+[![Build Status](https://travis-ci.org/wearefriday/spectre.svg?branch=master)](https://travis-ci.org/wearefriday/spectre)
+
 Spectre is a web application to diff screenshots. It's heavily influenced by [VisualReview](https://github.com/xebia/VisualReview), [BackstopJS](https://github.com/garris/BackstopJS) and [Wraith](https://github.com/BBC-News/wraith). Read more about how we use it at Friday in our blog post: [How we do visual regression testing](https://medium.com/friday-people/how-we-do-visual-regression-testing-af63fa8b8eb1).
 
 ![Spectre!](spectre_screenshot_1.png)

--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ Spectre doesn't provide a UI or API to edit or delete content. We've included `r
 ### Tests
 
 [Rspec](http://rspec.info/) and [Cucumber](https://cucumber.io) are included in the project.
-Test coverage is minimal but please don't follow our lead, write tests for anything you add. Use `rspec && rake cucumber` to run the existing tests.
+Test coverage is minimal but please don't follow our lead, write tests for anything you add. Use `rake` to run the existing tests.

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: [:spec, :cucumber]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,12 @@
   <body>
 
     <div class="masthead">
-      <div class="container">
+      <div class="container header">
         <a class="masthead__name" href="<%= projects_url %>">Spectre<img src="/favicon.gif" alt="" class="masthead__logo"></a>
-
       </div>
     </div>
 
-    <div class="container">
+    <div class="container body">
       <%= yield %>
     </div>
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -15,7 +15,7 @@
   <tbody>
     <% @projects.includes(:suites).each do |project| %>
       <% project.suites.each_with_index do |suite, i| %>
-      <tr id="project_<%= project.id %>">
+      <tr id="project_<%= project.id %>" class="project">
         <th><%= project.name %></th>
         <td><%= link_to suite.name, project_suite_path(suite.project, suite) %></td>
         <td><%= link_to "##{suite.latest_run.sequential_id}", project_suite_run_path(suite.project, suite, suite.latest_run) %> <span class="text-muted"><%= format_date(suite.latest_run.created_at) %></span>

--- a/features/step_definitions/projects_steps.rb
+++ b/features/step_definitions/projects_steps.rb
@@ -9,5 +9,7 @@ When(/^we visit the projects page$/) do
 end
 
 Then(/^we should see the projects$/) do
-  expect(page).to have_css('#project_1')
+  within ".body" do
+    expect(page.all("tr.project").count).to eq 3
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
Travis CI builds, for ruby 2.x versions.
I haven't put in ruby 1.9, mainly because the Gemfile has byebug, which needs ruby 2.x,
even though the main server runs under 1.9.
