### PR TITLE
crop_area param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,15 @@ Then you can submit a screenshot!
         platform: OSX,
         browser: PhantomJS,
         size: 1024,
-        screenshot: <File>
+        screenshot: <File>,
+        crop_area: '640x480+50+100'
 
 * `name` is a friendly name of your test. It should describe the template, component or state of the thing you've screenshotted
 * `platform` is the OS/platform that the screenshot was taken on (e.g. OSX, Windows, iOS, Android etc.)
 * `browser` is the browser that was used to render the screenshot. This will usually be a headless webkit such as Phantom, but if using Selenium you may have used a "real" browser
 * `size` is the screenshot size
 * `screenshot` is the image itself. PNGs are preferred
+* `crop_area` allows to specify a bounding box to crop from uploaded screenshot ("<width>x<height>+<top_left_x>+<top_left_y>"). If not specified, full screenshot is used for comparison. Can be used to perform visual diffs for specific page elements.
 
 ### Integration with Rake tasks or Cucumber
 

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -1,5 +1,4 @@
-require 'image_size'
-require 'image_geometry'
+require 'image_processor'
 
 class TestsController < ApplicationController
   skip_before_action :verify_authenticity_token
@@ -18,6 +17,7 @@ class TestsController < ApplicationController
   end
 
   def create
+    ImageProcessor.crop(test_params[:screenshot].path, test_params[:crop_area]) if test_params[:crop_area]
     @test = Test.create!(test_params)
     ScreenshotComparison.new(@test, test_params[:screenshot])
     render json: @test.to_json
@@ -26,7 +26,6 @@ class TestsController < ApplicationController
   private
 
   def test_params
-    params.require(:test).permit(:name, :browser, :size, :screenshot, :run_id, :source_url, :fuzz_level, :highlight_colour)
+    params.require(:test).permit(:name, :browser, :size, :screenshot, :run_id, :source_url, :fuzz_level, :highlight_colour, :crop_area)
   end
-
 end

--- a/app/models/screenshot_comparison.rb
+++ b/app/models/screenshot_comparison.rb
@@ -1,4 +1,5 @@
-require './lib/image_geometry'
+require 'image_size'
+require 'image_geometry'
 
 class ScreenshotComparison
   attr_reader :pass

--- a/db/migrate/20170410114210_add_crop_area_to_test.rb
+++ b/db/migrate/20170410114210_add_crop_area_to_test.rb
@@ -1,0 +1,5 @@
+class AddCropAreaToTest < ActiveRecord::Migration
+  def change
+    add_column :tests, :crop_area, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160510132620) do
+ActiveRecord::Schema.define(version: 20170410114210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20160510132620) do
     t.string   "source_url"
     t.string   "fuzz_level"
     t.string   "highlight_colour"
+    t.string   "crop_area"
   end
 
   add_index "tests", ["run_id"], name: "index_tests_on_run_id", using: :btree

--- a/lib/image_processor.rb
+++ b/lib/image_processor.rb
@@ -1,0 +1,17 @@
+require 'open3'
+
+class ImageProcessor
+  ##
+  # Crops the area in the image and saves it
+  #
+  # @param [String] src_image_path path to original image
+  # @param [String] crop_area [width]x[height]+[top_left_x]+[top_left_y]
+  # @param [String] dest_image_path path to save cropped image
+  #
+  # @return [Boolean] crop operation result (true/false)
+  #
+  def self.crop(src_image_path, crop_area, dest_image_path = src_image_path)
+    stdout_str, status = Open3.capture2("convert #{src_image_path.shellescape} -crop #{crop_area} #{dest_image_path.shellescape}")
+    status.exitstatus == 0
+  end
+end

--- a/spec/image_processor_spec.rb
+++ b/spec/image_processor_spec.rb
@@ -1,0 +1,8 @@
+require 'image_processor'
+
+RSpec.describe ImageProcessor do
+  it 'crops the image' do
+    result = ImageProcessor.crop('spec/support/images/testcard.jpg', '72x14+163+42', 'tmp/testcard_cropped.jpg')
+    expect(result).to be true
+  end
+end


### PR DESCRIPTION
Added a param to specify which part of screenshot should be used for a test. It is useful, when the page has a lot of "noise" and you need to test on specific elements (the coordinates of elements can be obtained via JS or via WebDriver API).