### PR TITLE
Update spectre_client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/wearefriday/spectre_client.git
-  revision: a83cbca5f054e749b5b6f912bf7610437d3bd2dc
+  revision: c55325a3a13b9a80c20985a73caae512e3778c3f
   specs:
     spectre_client (0.1.87)
       rest-client (~> 1.8.0)


### PR DESCRIPTION
Failing gemspec validation for the dependency `spectre_client` prevented installation of this package. `spectre_client` was fixed in https://github.com/wearefriday/spectre_client/pull/8 but `spectre` still needs to be updated to use it.