### PR TITLE
Add S3 as storage option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'rails_admin'
 gem 'sequenced'
 gem 'dragonfly', '~> 1.0.12'
+gem 'dragonfly-s3_data_store'
 gem 'image_size'
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,11 @@ GEM
       addressable (~> 2.3)
       multi_json (~> 1.0)
       rack (>= 1.3.0)
+    dragonfly-s3_data_store (1.3.0)
+      dragonfly (~> 1.0)
+      fog-aws
     erubis (2.7.0)
+    excon (0.73.0)
     execjs (2.7.0)
     factory_girl (4.9.0)
       activesupport (>= 3.0.0)
@@ -110,8 +114,25 @@ GEM
       factory_girl (~> 4.9.0)
       railties (>= 3.0.0)
     ffi (1.10.0)
+    fog-aws (3.6.2)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    formatador (0.2.5)
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -123,6 +144,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.0)
+    ipaddress (0.8.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -309,6 +331,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   dragonfly (~> 1.0.12)
+  dragonfly-s3_data_store
   factory_girl_rails (~> 4.0)
   image_size
   jbuilder (~> 2.0)

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -8,9 +8,18 @@ Dragonfly.app.configure do
 
   url_format "/media/:job/:name"
 
+  # If you want to use S3 to store your screenshots (if you're hosting on Heroku), comment the next section
+  # and uncomment the S3 datastore section.
+
   datastore :file,
     root_path: Rails.root.join('public/system/dragonfly', Rails.env),
     server_root: Rails.root.join('public')
+
+#  datastore :s3,
+#    bucket_name: 'YOUR_S3_BUCKET',
+#    access_key_id: 'YOUR_ACCESS_KEY',
+#    secret_access_key: 'YOUR_SECRET_ACCESS_KEY'
+
 end
 
 # Logger


### PR DESCRIPTION
This PR allows you to use S3 as a datastore for Spectre screenshots.  This way, you can host on Heroku and persist images.

Addresses https://github.com/wearefriday/spectre/issues/42