### PR TITLE
Add support of customized diff threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Then you can submit a screenshot!
         platform: OSX,
         browser: PhantomJS,
         size: 1024,
+        diff_threshold: 0.1,
         screenshot: <File>,
         crop_area: '640x480+50+100'
 
@@ -81,6 +82,7 @@ Then you can submit a screenshot!
 * `platform` is the OS/platform that the screenshot was taken on (e.g. OSX, Windows, iOS, Android etc.)
 * `browser` is the browser that was used to render the screenshot. This will usually be a headless webkit such as Phantom, but if using Selenium you may have used a "real" browser
 * `size` is the screenshot size
+* `diff_threshold` is the threshold of different pixels in percentage, it is optional and defaults to `0.1`
 * `screenshot` is the image itself. PNGs are preferred
 * `crop_area` allows to specify a bounding box to crop from uploaded screenshot ("<width>x<height>+<top_left_x>+<top_left_y>"). If not specified, full screenshot is used for comparison. Can be used to perform visual diffs for specific page elements.
 

--- a/app/assets/stylesheets/components/test.scss
+++ b/app/assets/stylesheets/components/test.scss
@@ -33,6 +33,13 @@
 }
 
 .test__diff {
+  @include font-size('medium');
+  display: block;
+  margin-bottom: 5px;
+  white-space: nowrap;
+}
+
+.test__diff-tolerance {
   @include font-size('small');
   display: block;
   margin-bottom: 5px;

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -19,13 +19,14 @@ class TestsController < ApplicationController
   def create
     ImageProcessor.crop(test_params[:screenshot].path, test_params[:crop_area]) if test_params[:crop_area]
     @test = Test.create!(test_params)
-    ScreenshotComparison.new(@test, test_params[:screenshot])
+    diff_threshold = test_params[:diff_threshold].presence || '0.1'
+    ScreenshotComparison.new(@test, test_params[:screenshot], diff_threshold.to_f)
     render json: @test.to_json
   end
 
   private
 
   def test_params
-    params.require(:test).permit(:name, :browser, :size, :screenshot, :run_id, :source_url, :fuzz_level, :highlight_colour, :crop_area)
+    params.require(:test).permit(:name, :browser, :size, :screenshot, :run_id, :source_url, :fuzz_level, :highlight_colour, :crop_area, :diff_threshold)
   end
 end

--- a/app/models/screenshot_comparison.rb
+++ b/app/models/screenshot_comparison.rb
@@ -4,11 +4,11 @@ require 'image_geometry'
 class ScreenshotComparison
   attr_reader :pass
 
-  def initialize(test, screenshot)
+  def initialize(test, screenshot, diff_threshold)
     determine_baseline_image(test, screenshot)
     image_paths = temp_screenshot_paths(test)
     compare_result = compare_images(test, image_paths)
-    @pass = determine_pass(test, image_paths, compare_result)
+    @pass = determine_pass(test, image_paths, compare_result, diff_threshold)
     test.pass = @pass
     save_screenshots(test, image_paths)
     remove_temp_files(image_paths)
@@ -68,13 +68,13 @@ class ScreenshotComparison
     "convert #{input_file.shellescape} -background white -extent #{canvas[:width]}x#{canvas[:height]} #{output_file.shellescape}"
   end
 
-  def determine_pass(test, image_paths, compare_result)
+  def determine_pass(test, image_paths, compare_result, diff_threshold)
     begin
       img_size = ImageSize.path(image_paths[:diff]).size.inject(:*)
       pixel_count = (compare_result.to_f / img_size) * 100
       test.diff = pixel_count.round(2)
-      # TODO: pull out 0.1 (diff threshhold to config variable)
-      (test.diff < 0.1)
+      test.diff_threshold = diff_threshold
+      (test.diff < diff_threshold)
     rescue
       # should probably raise an error here
     end

--- a/app/views/tests/_test.html.erb
+++ b/app/views/tests/_test.html.erb
@@ -11,8 +11,9 @@
   <td style="width:1px;"><%= link_to(thumbnail(test.screenshot_thumbnail), test.screenshot.url, class: 'test__image') unless test.screenshot.nil? %></td>
   <td style="width:1px;"><%= link_to(thumbnail(test.screenshot_diff_thumbnail), test.screenshot_diff.url, class: 'test__image') unless test.screenshot_diff.nil? %></td>
   <td>
-    <span class="test__diff text-muted"><%= test.diff == 0 ? 'No' : "#{test.diff}%" %> difference</span>
     <span class="test__status label label--<%= test.pass? ? 'pass' : 'fail' %>"><%= test.pass? ? 'Pass' : 'Fail' %></span>
+    <span class="test__diff text-muted"><%= test.diff == 0 ? 'No' : "#{test.diff}%" %> difference</span>
+    <span class="test__diff-tolerance text-muted"><%= "#{test.diff_threshold || 0.1}%" %> tolerance</span>
     <%# if test.five_consecutive_failures %>
       <!--span class="label label--warning">Consistently failing test</span-->
     <%# end %>

--- a/db/migrate/20220415064919_add_diff_threshold_to_test.rb
+++ b/db/migrate/20220415064919_add_diff_threshold_to_test.rb
@@ -1,0 +1,5 @@
+class AddDiffThresholdToTest < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tests, :diff_threshold, :float
+  end
+end


### PR DESCRIPTION
Hi, this PR is for adding support of diff threshold other than the fixed `0.1`. Code after change runs well during my test. 

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/7480839/166112993-f093fa4d-5dd4-4450-b859-52c1f785b5ec.png">

> The changes to the `Browser` and `Size` labels (in the `Test name` column) are not included in this PR. I can include them or submit another PR if they look good to you.

I do not know much about Ruby development so there might be some obvious problems in my change. I'll fix them if you could help point them out.

One known issue that `bundle exec rails db:migrate` has to be run right after `bundle exec rake db:setup` now. I can see the extra step is added because of the migration I've added. But I do not know if it is possible to merge this step into the previous setup step and how to do that. If it is not possible, the extra step should be added to the readme file.
